### PR TITLE
Fix license code to match the standard SPDX identifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [3.1.1] - 2026-07-01
+### Changed
+
+Marc Worrell (1):
+* Fix license code to match the standard SPDX identifier (#6)
+
 ## [3.1.0] - 2026-07-01
 ### Changed
 

--- a/src/erlang_exif.app.src
+++ b/src/erlang_exif.app.src
@@ -9,6 +9,6 @@
     ]},
     {env, []},
     {maintainers, ["Zotonic Team / Erlang Pack"]},
-    {licenses, ["BSD-3-Clause License"]},
+    {licenses, ["BSD-3-Clause"]},
     {links, [{"GitHub", "https://github.com/erlangpack/erlang_exif"}]}
 ]}.


### PR DESCRIPTION
This pull request makes a small update to the `src/erlang_exif.app.src` file, correcting the license name to match the standard SPDX identifier.